### PR TITLE
Expand directory or open file by o (like in NERDTree)

### DIFF
--- a/doc/vimpanel.txt
+++ b/doc/vimpanel.txt
@@ -169,7 +169,7 @@ the session called 'default'
 ==============================================================================
 3. Mappings inside the panel                               *Vimpanel-mappings*
 
-    <CR> or double-click            expand directory or open file
+    <CR>, double-click, o           expand directory or open file
     <F5>                            refresh panel
     <C-c> or yy                     copy selected node (file or dir)
     <C-v> or p                      paste nodes

--- a/plugin/vimpanel.vim
+++ b/plugin/vimpanel.vim
@@ -635,6 +635,7 @@ function! VimpanelBindMappings()
   " todo - make these keys configurable
   nnoremap <buffer> <silent> <CR>             :call vimpanel#selectNode()<CR>
   nnoremap <buffer> <silent> <2-LeftMouse>    :call vimpanel#selectNode()<CR>
+  nnoremap <buffer> <silent> o                :call vimpanel#selectNode()<CR>
   nnoremap <buffer> <silent> <C-r>            :call vimpanel#refreshNode()<CR>
 
   nnoremap <buffer> <F5>                      :VimpanelRefresh<CR>


### PR DESCRIPTION
I like Vimpanel, but it is quite hard to open files with double-click or Enter (or C-m) when the right hand is constantly on the `hjkl` keys. In NERDTree is a wonderful way to make it easier - `o` key.
I decided that this is exactly what is missing and added this support.
